### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Servant authentication with javascript web tokens
 This is by no means production ready and I would highly advice to NOT use this in production.
 The reasons are that currently the `jwt` package used is very incomplete and only verifies the signature of the jwt token and not actually the content.   This means people can use expired tokens to reach your API. Which is bad.
 
-I'm in the process of porting the thing to `jose`  to support more secure defaults
+Although this code could be adatped to use the `jose` library for more secure defaults, you probably want to [use `servant-auth` instead](https://haskell-servant.readthedocs.io/en/stable/cookbook/jwt-and-basic-auth/JWTAndBasicAuth.html).
 
 ## Usage
 


### PR DESCRIPTION
Points to the servant-auth page in the servant documentation.

If it doesn't bother you.